### PR TITLE
Update Vercel config to support Prisma migration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,10 @@
   "builds": [
     {
       "src": "backend/server.js",
-      "use": "@vercel/node"
+      "use": "@vercel/node",
+      "config": {
+        "buildCommand": "npx prisma generate"
+      }
     },
     {
       "src": "frontend/package.json",


### PR DESCRIPTION
This PR updates the Vercel configuration to support the migration from Sequelize to Prisma in the backend service. The change adds a `buildCommand` to generate the Prisma client during deployment.