### PR TITLE
Fix authentication redirect bug when uploading images

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -93,7 +93,7 @@ router.post(
       console.error('Registration error:', error)
       res.status(500).json({ error: 'Registration failed' })
     }
-  }
+  },
 )
 
 // @route   POST /api/auth/login
@@ -121,7 +121,7 @@ router.post('/login', validate(loginSchema), async (req, res) => {
     res.cookie('jwt', token, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
-      sameSite: 'strict',
+      sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
       maxAge: 24 * 60 * 60 * 1000, // 1 day
     })
 


### PR DESCRIPTION
## Description
This PR fixes an authentication bug where users are redirected to the login page when uploading images in the RecipeForm.

## Root Cause
The JWT token is stored in an `httpOnly` cookie. The cookie was set with `sameSite: 'strict'`, which prevents sending the cookie for cross-origin requests. In development (localhost:5173 to localhost:5001) and production (separate Vercel deployments), this causes 401 errors on authenticated endpoints like `/api/upload`.

## Changes
- Updated `backend/routes/auth.js` to set `sameSite: 'none'` in production (allows cross-origin with HTTPS) and `'lax'` in development (allows localhost cross-port).
- Maintains security: `secure: true` in production ensures HTTPS-only.

## Testing
- Rebuild Docker containers for dev testing.
- Deploy to production to verify the fix.

Fixes the issue where selecting an image and clicking save redirects to login.